### PR TITLE
fix: correct workflow bugs, README markup, and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions" # workflows under .github/workflows
-    directory: "/" # Location of package manifests
+    directory: "/" # repo root; Dependabot scans .github/workflows
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "github-actions" # workflows under .github/workflows
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.github/workflows/profile-3d.yml
+++ b/.github/workflows/profile-3d.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/profile-3d.yml
+++ b/.github/workflows/profile-3d.yml
@@ -15,13 +15,13 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: generate-github-profile-3d-contrib
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - uses: yoshi389111/github-profile-3d-contrib@0.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           USERNAME: ${{ github.repository_owner }}
       - name: Checkout output branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
             ref: output
             path: output-branch

--- a/.github/workflows/profile-3d.yml
+++ b/.github/workflows/profile-3d.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: generate-github-profile-3d-contrib
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    - main
+      - main
 
 permissions:
   contents: write

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: write
+
 jobs:
   generate-github-snake-contrib:
     runs-on: ubuntu-latest

--- a/.github/workflows/snake.yml
+++ b/.github/workflows/snake.yml
@@ -2,7 +2,7 @@ name: Generate snake animation
 
 on:
   schedule: # execute every 12 hours
-    - cron: "* */12 * * *"
+    - cron: "0 */12 * * *"
   workflow_dispatch:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@
       <img 
         src="https://raw.githubusercontent.com/dourado/dourado/main/src/today.png"
         height="40">
+    </picture>
   </a>
   <a href="https://stackoverflow.com/users/15846522/dourado" target="__blank">
     <picture>


### PR DESCRIPTION
## What

Independent fixes and hardening across the profile repo's workflows, README, and Dependabot config.

**Workflows**
- **snake cron** — `* */12 * * *` matched every minute during hours 0 and 12 (~120 runs/day); pinned to `0 */12 * * *` so it runs twice a day.
- **profile-3d manual dispatch** — the job's `if` guard only checked `workflow_run.conclusion`, which is null on `workflow_dispatch`, so manual runs were always skipped. It now also allows `workflow_dispatch`.
- **actions/checkout** — bumped from the deprecated `@v2` (Node 12 runtime) to `@v7` in both steps.
- **GITHUB_TOKEN permissions** — both workflows ran with default broad permissions (CodeQL `actions/missing-workflow-permissions`); scoped to `contents: write` (both push to the `output` branch).
- **snake `on.push.branches`** — indented the list under `branches:` for readability.

**README**
- Closed an unclosed `<picture>` element around the "today" badge that left the markup malformed.

**Dependabot**
- Set `package-ecosystem` to `github-actions` — the template's empty value is invalid and made Dependabot reject the whole config. This repo only ships Actions workflows.
- Clarified the `directory` comment for the github-actions ecosystem.

## Why

Several of these were silent breakage (cron burning Actions minutes, dead manual dispatch, invalid Dependabot config); the rest are security/maintenance hardening surfaced by CodeQL and review.