### PR TITLE
chore: add CODEOWNERS with @dourado as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in this repo.
+* @dourado


### PR DESCRIPTION
## What

Add `.github/CODEOWNERS` with a catch-all owner:

```
* @dourado
```

## Why

The `main` branch protection has `require_code_owner_reviews: true`, but no `CODEOWNERS` file existed — so the rule had no owners to enforce. This sets `@dourado` as the default owner for the whole repo.

> Note: with code-owner reviews required and `@dourado` as the sole owner, PRs authored by `@dourado` can't be self-approved and may need an admin bypass to merge.